### PR TITLE
Update whoami-el-nuevo-ataque-que-explota-la-confusion-de-nombres-en-…

### DIFF
--- a/src/data/articles/2025/02/17/whoami-el-nuevo-ataque-que-explota-la-confusion-de-nombres-en-aws-ami.md
+++ b/src/data/articles/2025/02/17/whoami-el-nuevo-ataque-que-explota-la-confusion-de-nombres-en-aws-ami.md
@@ -33,7 +33,7 @@ AWS fue notificada del problema el 16 de septiembre de 2024 y abordó la vulnera
 
 Para mitigar este riesgo, AWS ha introducido una nueva configuración llamada "Allowed AMIs", que permite a los administradores limitar el descubrimiento y uso de AMIs dentro de sus cuentas. Se recomienda a los clientes evaluar e implementar esta medida de seguridad.
 
-![whoAMI - hacker server](../assets/images/whoami.avif "whoAMI")
+![whoAMI - hacker server](../../../../../assets/images/whoami.avif "whoAMI")
 
 Además, HashiCorp Terraform ha tomado acciones al respecto. En la versión 5.77.0 de su proveedor de AWS, se ha agregado una advertencia para los usuarios que utilicen `most_recent = true` sin un filtro de propietario. Se espera que esta advertencia se convierta en un error obligatorio en la versión 6.0.0.
 


### PR DESCRIPTION
This pull request includes changes to update the image path in an article about a new attack exploiting name confusion in AWS AMI. The most important change is:

* [`src/data/articles/2025/02/17/whoami-el-nuevo-ataque-que-explota-la-confusion-de-nombres-en-aws-ami.md`](diffhunk://#diff-b0e304c1ac13b0a67b7727f357014151f1bb019faf17525330f9b8cead41f071L36-R36): Updated the image path for `whoami.avif` to a more accurate relative path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the image reference in an article to ensure the "whoAMI - hacker server" graphic displays correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->